### PR TITLE
Fix version-handling for Node.js and Discord.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-if (process.version.split('.')[0].substring(1) < 14) throw new Error("Discord.js requires NodeJS version >= 14.0.0, for Music Handlers now. Please update your Node at https://nodejs.org/en/.");
 module.exports = {
     version: require('./package.json').version,
     Player: require('./src/Player'),

--- a/src/Player.js
+++ b/src/Player.js
@@ -2,7 +2,7 @@ const ytdl = require('ytdl-core');
 const mergeOptions = require('merge-options');
 const ytsr = require('ytsr');
 const { VoiceChannel, version, User } = require("discord.js");
-if (version.split('.')[0] !== '12') throw new Error("Only the master branch of discord.js library is supported for now. Install it using 'npm install discordjs/discord.js'.");
+if (Number(version.split('.')[0]) < 12) throw new Error("Only the master branch of discord.js library is supported for now. Install it using 'npm install discordjs/discord.js'.");
 const Queue = require('./Queue');
 const Util = require('./Util');
 const Song = require('./Song');


### PR DESCRIPTION
Why?

1) Discord.js still didn't switch to the newer version, where it requires you to have Node.js' v14 or above
2) Discord.js COULD update to v13 and the module would say "Only the master branch of discord.js library is supported for now", which doesn't make much sense