### PR TITLE
Bump ytdl-core to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "miniget": "^4.1.0",
     "scrape-yt": "^1.4.7",
     "spotify-url-info": "^2.2.0",
-    "ytdl-core": "^4.4.5",
+    "ytdl-core": "^4.5.0",
     "ytsr": "^3.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Its a minor version so it shouldn't break anything. As of the latest ytdl-core version, you get warnings in the console because its outdated, so this will prevent those warnings.