### PR TITLE
safety object on Object.assign

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -771,7 +771,7 @@ class Player extends EventEmitter {
             return null;
         }
 
-        queue.options = Object.assign(Util.PlayerOptions, options);
+        queue.options = Object.assign({}, Util.PlayerOptions, options);
     }
 
     /**

--- a/src/Util.js
+++ b/src/Util.js
@@ -131,7 +131,7 @@ class Util {
     static getVideoBySearch(search, options = {}, queue, requestedBy) {
         return new Promise(async (resolve, reject) => {
 
-            options = Object.assign(defaultSearchOptions, options);
+            options = Object.assign({}, defaultSearchOptions, options);
             options = pick(options, Object.keys(defaultSearchOptions))
 
             if(SpotifyRegex.test(search)) {
@@ -370,7 +370,7 @@ class Util {
      */
     static deserializeOptionsPlayer(options) {
         if(options && typeof options === 'object')
-            return Object.assign(this.PlayerOptions, options);
+            return Object.assign({}, this.PlayerOptions, options);
         else return this.PlayerOptions;
     }
 
@@ -380,9 +380,9 @@ class Util {
      */
     static deserializeOptionsPlay(options) {
         if(options && typeof options === 'object')
-            return Object.assign(this.PlayOptions, options);
+            return Object.assign({}, this.PlayOptions, options);
         else if(typeof options === 'string')
-            return Object.assign(this.PlayOptions, { search: options });
+            return Object.assign({}, this.PlayOptions, { search: options });
         else return this.PlayOptions;
     }
 
@@ -392,9 +392,9 @@ class Util {
      */
     static deserializeOptionsPlaylist(options) {
         if(options && typeof options === 'object')
-            return Object.assign(this.PlaylistOptions, options);
+            return Object.assign({}, this.PlaylistOptions, options);
         else if(typeof options === 'string')
-            return Object.assign(this.PlaylistOptions, { search: options });
+            return Object.assign({}, this.PlaylistOptions, { search: options });
         else return this.PlaylistOptions;
     }
 
@@ -404,7 +404,7 @@ class Util {
      */
     static deserializeOptionsProgress(options) {
         if(options && typeof options === 'object')
-            return Object.assign(this.ProgressOptions, options);
+            return Object.assign({}, this.ProgressOptions, options);
         else return this.ProgressOptions;
     }
 


### PR DESCRIPTION
Object.assign assignes the second object to the first one, that's why it's better to add an empty object as the first parameter.