### PR TITLE
fix double error event

### DIFF
--- a/src/managers/ProgressBar.ts
+++ b/src/managers/ProgressBar.ts
@@ -57,7 +57,7 @@ class ProgressBar {
     private create() {
         const { size, arrow, block } = this.options;
         const currentTime = this.queue.nowPlaying.seekTime + this.queue.connection.time;
-        const progress = Math.round((size! * currentTime / this.queue.nowPlaying.millisecons));
+        const progress = Math.round((size! * currentTime / this.queue.nowPlaying.milliseconds));
         const emptyProgress = size! - progress;
 
         const progressString = block!.repeat(progress) + arrow! + ' '.repeat(emptyProgress);

--- a/src/managers/Queue.ts
+++ b/src/managers/Queue.ts
@@ -229,7 +229,8 @@ export class Queue {
             highWaterMark: 1 << 25
         })
             .on('error', (error: { message: string; }) => {
-                if(!error.message.toLowerCase().includes("premature close"))
+                // avoid repeated error messages conflicting with the emit error in join()
+                if(!/Status code|premature close/i.test(error.message))
                     this.player.emit('error', error.message === 'Video unavailable' ? 'VideoUnavailable' : error.message, this);
                return;
             });
@@ -296,7 +297,7 @@ export class Queue {
             return;
         if (time < 1)
             time = 0;
-        if (time >= this.nowPlaying.millisecons)
+        if (time >= this.nowPlaying.milliseconds)
             return this.skip();
 
         await this.play(this.nowPlaying, {


### PR DESCRIPTION
Prevent that the event emit('error') fired in play() and join() with connection errors like 403 or 410

Maybe the event 'error' in the YTDL connection is not necessary, is it always caught by the connection.on('error') ??

issue #228 