### PR TITLE
fix: 🐛 leaveOnEmpty not working while song playing

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -136,7 +136,7 @@ export class Player extends EventEmitter {
         if (!leaveOnEmpty || queue.connection.channel.members.size > 1) return;
         setTimeout(() => {
             if (queue!.connection.channel.members.size > 1) return;
-            if (queue!.connection.channel.members.size === 1 && queue!.connection.channel.members.get(this.client.user!.id)?.user.id === this.client.user?.id) {
+            if (queue!.connection.channel.members.has(this.client.user!.id)) {
                 queue!.destroy(true);
                 this.emit('channelEmpty', queue);
             }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -135,9 +135,11 @@ export class Player extends EventEmitter {
         if (oldState.channelId === newState.channelId) return;
         if (!leaveOnEmpty || queue.connection.channel.members.size > 1) return;
         setTimeout(() => {
-            if (queue!.connection.channel.members.size > 1 || queue!.songs.length !== 0) return;
-            queue!.destroy(true);
-            this.emit('channelEmpty', queue);
+            if (queue!.connection.channel.members.size > 1) return;
+            if (queue!.connection.channel.members.size === 1 && queue!.connection.channel.members.get(this.client.user!.id)?.user.id === this.client.user?.id) {
+                queue!.destroy(true);
+                this.emit('channelEmpty', queue);
+            }
         }, timeout);
     }
 }


### PR DESCRIPTION
fix: #240

this PR fixes the condition where the event `"channelEmpty"` is being emitted. It checks if the last member on the voice chat is the bot and regardless if there are still songs currently playing this event will be fired.