### PR TITLE
Change type of `Queue#connection` and `Queue#nowPlaying` to include `undefined`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-music-player",
-  "version": "8.1.0",
+  "version": "8.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-music-player",
-      "version": "8.1.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
         "@discordjs/opus": "^0.6.0",

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -135,7 +135,7 @@ export class Player extends EventEmitter {
         if (oldState.channelId === newState.channelId) return;
         if (!leaveOnEmpty || queue.connection.channel.members.size > 1) return;
         setTimeout(() => {
-            if (queue!.connection.channel.members.size > 1 || queue!.songs.length !== 0) return;
+            if (queue!.connection!.channel.members.size > 1 || queue!.songs.length !== 0) return;
             queue!.destroy(true);
             this.emit('channelEmpty', queue);
         }, timeout);

--- a/src/managers/ProgressBar.ts
+++ b/src/managers/ProgressBar.ts
@@ -1,11 +1,10 @@
-import { DefaultProgressBarOptions, ProgressBarOptions, Queue, Utils } from "..";
-
+import { DefaultProgressBarOptions, DMPError, DMPErrors, ProgressBarOptions, Queue, Utils } from "..";
 
 class ProgressBar {
     private queue: Queue;
     options: ProgressBarOptions = DefaultProgressBarOptions;
-    bar: string;
-    times: string;
+    bar!: string;
+    times!: string;
 
     /**
      * ProgressBar constructor
@@ -39,6 +38,13 @@ class ProgressBar {
          * @type {string}
          */
 
+        if(queue.destroyed)
+            throw new DMPError(DMPErrors.QUEUE_DESTROYED);
+        if(!queue.connection)
+            throw new DMPError(DMPErrors.NO_VOICE_CONNECTION);
+        if(!queue.isPlaying)
+            throw new DMPError(DMPErrors.NOTHING_PLAYING);
+
         this.queue = queue;
 
         this.options = Object.assign(
@@ -56,14 +62,14 @@ class ProgressBar {
      */
     private create() {
         const { size, arrow, block } = this.options;
-        const currentTime = this.queue.nowPlaying.seekTime + this.queue.connection.time;
-        const progress = Math.round((size! * currentTime / this.queue.nowPlaying.milliseconds));
+        const currentTime = this.queue.nowPlaying!.seekTime + this.queue.connection!.time;
+        const progress = Math.round((size! * currentTime / this.queue.nowPlaying!.milliseconds));
         const emptyProgress = size! - progress;
 
         const progressString = block!.repeat(progress) + arrow! + ' '.repeat(emptyProgress);
 
         this.bar = progressString;
-        this.times = `${Utils.msToTime(currentTime)}/${this.queue.nowPlaying.duration}`;
+        this.times = `${Utils.msToTime(currentTime)}/${this.queue.nowPlaying!.duration}`;
     }
 
     /**

--- a/src/managers/Queue.ts
+++ b/src/managers/Queue.ts
@@ -9,7 +9,7 @@ import { Playlist, Song, Player, Utils, DefaultPlayerOptions, PlayerOptions, Pla
 export class Queue {
     public player: Player;
     public guild: Guild;
-    public connection: StreamConnection;
+    public connection: StreamConnection | undefined;
     public songs: Song[] = [];
     public isPlaying: boolean = false;
     public data?: any = null;
@@ -42,7 +42,7 @@ export class Queue {
         /**
          * Queue connection
          * @name Queue#connection
-         * @type {StreamConnection}
+         * @type {?StreamConnection}
          * @readonly
          */
 
@@ -184,7 +184,7 @@ export class Queue {
     async play(search: Song | string, options: PlayOptions & { immediate?: boolean, seek?: number, data?: any } = DefaultPlayOptions): Promise<Song> {
         if(this.destroyed)
             throw new DMPError(DMPErrors.QUEUE_DESTROYED);
-        if(!this.connection?.connection)
+        if(!this.connection)
             throw new DMPError(DMPErrors.NO_VOICE_CONNECTION);
         options = Object.assign(
             {} as PlayOptions,
@@ -243,7 +243,7 @@ export class Queue {
         });
 
         setTimeout(_ => {
-            this.connection.playAudioStream(resource)
+            this.connection!.playAudioStream(resource)
                 .then(__ => {
                     this.setVolume(this.options.volume!);
                 })
@@ -261,7 +261,7 @@ export class Queue {
     async playlist(search: Playlist | string, options: PlaylistOptions & { data?: any } = DefaultPlaylistOptions): Promise<Playlist> {
         if(this.destroyed)
             throw new DMPError(DMPErrors.QUEUE_DESTROYED);
-        if(!this.connection?.connection)
+        if(!this.connection)
             throw new DMPError(DMPErrors.NO_VOICE_CONNECTION);
         options = Object.assign(
             {} as PlaylistOptions & { data?: any },
@@ -299,10 +299,10 @@ export class Queue {
             return;
         if (time < 1)
             time = 0;
-        if (time >= this.nowPlaying.milliseconds)
+        if (time >= this.nowPlaying!.milliseconds)
             return this.skip();
 
-        await this.play(this.nowPlaying, {
+        await this.play(this.nowPlaying!, {
             immediate: true,
             seek: time
         });
@@ -318,6 +318,8 @@ export class Queue {
     skip(index: number = 0): Song {
         if(this.destroyed)
             throw new DMPError(DMPErrors.QUEUE_DESTROYED);
+        if(!this.connection)
+            throw new DMPError(DMPErrors.NO_VOICE_CONNECTION);
         this.songs.splice(1, index);
 
         const skippedSong = this.songs[0];
@@ -359,6 +361,8 @@ export class Queue {
     setPaused(state: boolean = true): boolean|undefined {
         if(this.destroyed)
             throw new DMPError(DMPErrors.QUEUE_DESTROYED);
+        if(!this.connection)
+            throw new DMPError(DMPErrors.NO_VOICE_CONNECTION);
         if(!this.isPlaying)
             throw new DMPError(DMPErrors.NOTHING_PLAYING);
 
@@ -398,6 +402,8 @@ export class Queue {
     get paused(): boolean {
         if(this.destroyed)
             throw new DMPError(DMPErrors.QUEUE_DESTROYED);
+        if(!this.connection)
+            throw new DMPError(DMPErrors.NO_VOICE_CONNECTION);
         if(!this.isPlaying)
             throw new DMPError(DMPErrors.NOTHING_PLAYING);
 
@@ -412,6 +418,8 @@ export class Queue {
     setVolume(volume: number) {
         if(this.destroyed)
             throw new DMPError(DMPErrors.QUEUE_DESTROYED);
+        if(!this.connection)
+            throw new DMPError(DMPErrors.NO_VOICE_CONNECTION);
 
         this.options.volume = volume;
         return this.connection.setVolume(volume);
@@ -419,10 +427,10 @@ export class Queue {
 
     /**
      * Returns current playing song
-     * @type {Song}
+     * @type {?Song}
      */
-    get nowPlaying() {
-        return this.connection.resource?.metadata ?? this.songs[0];
+    get nowPlaying(): Song | undefined {
+        return this.connection?.resource?.metadata ?? this.songs[0];
     }
 
     /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "rootDir": "src",
     "outDir": "dist",
     "strict": true,
-    "strictPropertyInitialization": false,
     "esModuleInterop": true,
     "pretty": true,
     "resolveJsonModule": true


### PR DESCRIPTION
`Queue#connection` can be `undefined` when the queue hasn't joined a channel yet. I was quite surprised when my program crashed due to this `connection` property being `undefined`, despite the types saying it can't be `undefined`. This PR removes the `"strictPropertyInitialization": false` in tsconfig so that these incorrect types hopefully don't happen again. (I'm not quite sure why this was set to `false` in the first place, so I'm happy to revert it if needed.)

This PR also changes the type of `Queue#nowPlaying` to `Song | undefined` (instead of `Song`) because it can be `undefined` when the queue isn't playing anything.