### PR TITLE
improve Queue#remove implementation

### DIFF
--- a/src/managers/Queue.ts
+++ b/src/managers/Queue.ts
@@ -374,11 +374,7 @@ export class Queue {
         if(this.destroyed)
             throw new DMPError(DMPErrors.QUEUE_DESTROYED);
 
-        let song = this.songs[index];
-        if (song)
-            this.songs = this.songs.filter((s) => s !== song);
-
-        return song;
+        return this.songs.splice(index, 1)[0];
     }
 
     /**


### PR DESCRIPTION
Using `splice` is more efficient than `filter`ing out the song at the index. Additionally, the previous implementation would yield unexpected results if the same `Song` object is used multiple times in the queue (e.g. if the queue was `[song1, song2, song3, song2]`, `queue.remove(1)` would result in the queue being `[song1, song3]` instead of `[song1, song3, song2]`). This might be intentional, however I doubt it.