### PR TITLE
stop() changes behavior

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -126,7 +126,7 @@ export class Player extends EventEmitter {
         let { deafenOnJoin, leaveOnEmpty, timeout } = queue.options;
 
         if (!newState.channelId && this.client.user?.id === oldState.member?.id) {
-            queue.destroy();
+            queue.leave();
             return void this.emit('clientDisconnect', queue);
         } else if(deafenOnJoin && oldState.serverDeaf && !newState.serverDeaf) {
             this.emit('clientUndeafen', queue);
@@ -137,7 +137,7 @@ export class Player extends EventEmitter {
         setTimeout(() => {
             if (queue!.connection!.channel.members.size > 1) return;
             if (queue!.connection!.channel.members.has(this.client.user!.id)) {
-                queue!.destroy(true);
+                queue!.leave();
                 this.emit('channelEmpty', queue);
             }
         }, timeout);

--- a/src/voice/StreamConnection.ts
+++ b/src/voice/StreamConnection.ts
@@ -184,11 +184,8 @@ export class StreamConnection extends EventEmitter {
      * @returns {void}
      */
     leave() {
-        try {
-            this.player.stop(true);
-            this.connection.destroy();
-        }
-        catch (e) {}
+        this.player.stop(true);
+        this.connection.destroy();
     }
 
     /**

--- a/src/voice/StreamConnection.ts
+++ b/src/voice/StreamConnection.ts
@@ -61,9 +61,10 @@ export class StreamConnection extends EventEmitter {
             if (newState.status === VoiceConnectionStatus.Disconnected) {
                 if (newState.reason === VoiceConnectionDisconnectReason.WebSocketClose && newState.closeCode === 4014) {
                     try {
+                        // Attempting to re-join the voice channel, after possibly changing channels
                         await entersState(this.connection, VoiceConnectionStatus.Connecting, 5_000);
                     } catch {
-                        this.leave();
+                        // It was mannually disconnected and the connection is closed in Player.js _voiceUpdate
                     }
                 } else if (this.connection.rejoinAttempts < 5) {
                     await wait((this.connection.rejoinAttempts + 1) * 5_000);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES6",
+    "target": "es2020",
     "module": "commonjs",
     "allowJs": true,
     "declaration": true,


### PR DESCRIPTION
stop() now clear the queue and skip the current song
leave() replaces private destroy()
fix max listeners exceeded

issue #248 

with `this.connection.stop();` does not destroy the VoiceConnection instance and in the join() the function joinVoiceChannel() recover the previous one and that one gets used for creating a new StreamConnection, adding the same listener again and again

also destroy() now is leave() and is simplier