### PR TITLE
Changed Utils.search to Utils.searchSong

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "discord-music-player",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "8.3.0",
+      "name": "discord-music-player",
+      "version": "8.3.1",
       "license": "MIT",
       "dependencies": {
         "@discordjs/opus": "^0.6.0",

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -46,7 +46,7 @@ export interface PlayOptions {
     index?: number;
     requestedBy?: User,
     localAddress?: string
-};
+}
 
 /**
  * Playlist options
@@ -61,7 +61,7 @@ export interface PlaylistOptions {
     requestedBy?: User,
     shuffle?: boolean,
     localAddress?: string
-};
+}
 
 /**
  * @typedef {object} ProgressBarOptions

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -66,7 +66,7 @@ export class Utils {
      * @param {number} [Limit=1]
      * @return {Promise<Song[]>}
      */
-    static async search(Search: string, SOptions: PlayOptions = DefaultPlayOptions, Queue: Queue, Limit: number = 1): Promise<Song[]> {
+    static async searchSong(Search: string, SOptions: PlayOptions = DefaultPlayOptions, Queue: Queue, Limit: number = 1): Promise<Song[]> {
         SOptions = Object.assign({}, DefaultPlayOptions, SOptions);
         let Filters;
 
@@ -156,7 +156,7 @@ export class Utils {
         if (AppleLink) {
             try {
                 let AppleResult = await getSong(Search);
-                let SearchResult = await this.search(
+                let SearchResult = await this.searchSong(
                     `${AppleResult.artist} - ${AppleResult.title}`,
                     SOptions,
                     Queue
@@ -169,7 +169,7 @@ export class Utils {
         } else if(SpotifyLink) {
             try {
                 let SpotifyResult = await getPreview(Search);
-                let SearchResult = await this.search(
+                let SearchResult = await this.searchSong(
                     `${SpotifyResult.artist} - ${SpotifyResult.title}`,
                     SOptions,
                     Queue
@@ -223,7 +223,7 @@ export class Utils {
         );
 
         if(!_Song)
-            _Song = (await this.search(
+            _Song = (await this.searchSong(
                 Search,
                 SOptions,
                 Queue
@@ -270,7 +270,7 @@ export class Utils {
                     AppleResultData.tracks.map(async (track, index) => {
                         if (Limit !== -1 && index >= Limit)
                             return null;
-                        const Result = await this.search(
+                        const Result = await this.searchSong(
                             `${track.artist} - ${track.title}`,
                             SOptions,
                             Queue
@@ -311,7 +311,7 @@ export class Utils {
                             return null;
                         if (SpotifyResult.type === 'playlist')
                             track = track.track
-                        const Result = await this.search(
+                        const Result = await this.searchSong(
                             `${track.artists[0].name} - ${track.name}`,
                             SOptions,
                             Queue


### PR DESCRIPTION
I changed the function because it causes a conflict with JavaScript [String.prototype.search()](https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Global_Objects/String/search)

from .search() to .searchSong()

The problem only appears when you require Utils like this:

```js
const {Utils} = require("discord-music-player") // it shows the problem
const DMP = require("discord-music-player") // it doesn't show the problem
```