### PR TITLE
Support index option when adding a playlist

### DIFF
--- a/src/managers/Queue.ts
+++ b/src/managers/Queue.ts
@@ -270,7 +270,9 @@ export class Queue {
                 throw new DMPError(error);
             });
         let songLength = this.songs.length;
-        this.songs.push(...playlist.songs);
+        if(options?.index! >= 0 && ++options.index! <= songLength)
+            this.songs.splice(options.index!, 0, ...playlist.songs);
+        else this.songs.push(...playlist.songs);
         this.player.emit('playlistAdd', this, playlist);
 
         if(songLength === 0) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -54,12 +54,14 @@ export interface PlayOptions {
  * @param {number} [maxSongs=-1] Max songs
  * @param {User} [requestedBy] The User who requested the Song
  * @param {boolean} [shuffle=false] If it should shuffle the Songs
+ * @param {number} [index] If the index was provided, it will add all songs of the playlist after the provided index in the Queue
  * @param {string} [localAddress] Custom ipv4/ipv6 address
  */
 export interface PlaylistOptions {
     maxSongs?: number,
     requestedBy?: User,
     shuffle?: boolean,
+    index?: number,
     localAddress?: string
 };
 


### PR DESCRIPTION
When adding a song to a queue, there is an option to add the song after a specific index in the queue.

This PR adds the same functionality when adding a playlist to a queue. If `index` is specified in the options, all the songs from the playlist will be inserted after the given index.