### PR TITLE
Move conditional to make destroying the connection safer

### DIFF
--- a/src/voice/StreamConnection.ts
+++ b/src/voice/StreamConnection.ts
@@ -82,8 +82,7 @@ export class StreamConnection extends EventEmitter {
                 try {
                     await this._enterState();
                 } catch {
-                    if (this.connection.state.status !== VoiceConnectionStatus.Destroyed)
-                        this.leave();
+                    this.leave();
                 } finally {
                     this.readyLock = false;
                 }
@@ -186,7 +185,8 @@ export class StreamConnection extends EventEmitter {
      */
     leave() {
         this.player.stop(true);
-        this.connection.destroy();
+        if (this.connection.state.status !== VoiceConnectionStatus.Destroyed)
+            this.connection.destroy();
     }
 
     /**


### PR DESCRIPTION
A `Cannot destroy VoiceConnection` error is thrown when the client is forcefully disconnected by a user and leaveOnEmpty, leaveOnEnd, or leaveOnStop is set to true.

To fix this, the check for if the voice connection has been destroyed has been moved directly before `this.connection.destroy()` in `StreamConnection.leave()`. This way, the check will always run before attempting to destroy it.