### PR TITLE
Fix URLs not playing by updating youtubei to 0.0.1-rc.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "discord-music-player",
-  "version": "8.3.0",
+  "version": "8.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "8.3.0",
+      "name": "discord-music-player",
+      "version": "8.3.2",
       "license": "MIT",
       "dependencies": {
         "@discordjs/opus": "^0.6.0",
@@ -18,7 +19,7 @@
         "htmlparser2": "^7.1.2",
         "libsodium-wrappers": "^0.7.9",
         "spotify-url-info": "^2.2.3",
-        "youtubei": "^0.0.1-rc.27",
+        "youtubei": "^0.0.1-rc.34",
         "ytdl-core": "^4.9.1",
         "ytsr": "^3.5.3"
       },
@@ -11159,9 +11160,9 @@
       }
     },
     "node_modules/youtubei": {
-      "version": "0.0.1-rc.27",
-      "resolved": "https://registry.npmjs.org/youtubei/-/youtubei-0.0.1-rc.27.tgz",
-      "integrity": "sha512-4pbKr6F9RpWQ/XLstD9KNTBd5dGkzXNm8sx2ooQFleCka/wknZQhu9HEoGbvJMb4izvfSs2e5TAAK+l6fYwxJQ=="
+      "version": "0.0.1-rc.34",
+      "resolved": "https://registry.npmjs.org/youtubei/-/youtubei-0.0.1-rc.34.tgz",
+      "integrity": "sha512-7EbAoJ8wKlOq2+2Y9F6BhDK85Vr7XkacW44g7F2++up/lncdwRVXcz/Q4vOxxMZcvadEWPOc/78U10GQUeI1fw=="
     },
     "node_modules/ytdl-core": {
       "version": "4.9.1",
@@ -19707,9 +19708,9 @@
       "dev": true
     },
     "youtubei": {
-      "version": "0.0.1-rc.27",
-      "resolved": "https://registry.npmjs.org/youtubei/-/youtubei-0.0.1-rc.27.tgz",
-      "integrity": "sha512-4pbKr6F9RpWQ/XLstD9KNTBd5dGkzXNm8sx2ooQFleCka/wknZQhu9HEoGbvJMb4izvfSs2e5TAAK+l6fYwxJQ=="
+      "version": "0.0.1-rc.34",
+      "resolved": "https://registry.npmjs.org/youtubei/-/youtubei-0.0.1-rc.34.tgz",
+      "integrity": "sha512-7EbAoJ8wKlOq2+2Y9F6BhDK85Vr7XkacW44g7F2++up/lncdwRVXcz/Q4vOxxMZcvadEWPOc/78U10GQUeI1fw=="
     },
     "ytdl-core": {
       "version": "4.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-music-player",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "description": "Complete framework to facilitate music commands using discord.js v13",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -41,7 +41,7 @@
     "htmlparser2": "^7.1.2",
     "libsodium-wrappers": "^0.7.9",
     "spotify-url-info": "^2.2.3",
-    "youtubei": "^0.0.1-rc.27",
+    "youtubei": "^0.0.1-rc.34",
     "ytdl-core": "^4.9.1",
     "ytsr": "^3.5.3"
   },


### PR DESCRIPTION
youtubei made a [recent update](https://github.com/SuspiciousLookingOwl/youtubei/commit/a749770920a1515fe9e99088177319db53ba98ea) to fix an error with how it handles some responses it gets back.

This error is the root of a recently occurring bug where trying to play from URLs results in an error being thrown.