### PR TITLE
accepts type for option data

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -4,9 +4,9 @@ import { DMPError, DMPErrors } from ".";
 import { Queue } from "./managers/Queue";
 import { PlayerOptions, DefaultPlayerOptions, PlayerEvents } from "./types/types";
 
-export class Player extends EventEmitter {
+export class Player<OptionsData = any> extends EventEmitter {
     public client: Client;
-    public queues: Collection<Snowflake, Queue> = new Collection();
+    public queues: Collection<Snowflake, Queue<OptionsData>> = new Collection();
     public options: PlayerOptions = DefaultPlayerOptions;
 
     /**
@@ -38,7 +38,7 @@ export class Player extends EventEmitter {
          * Player queues
          * @type {Collection<Snowflake, Queue>}
          */
-        this.queues = new Collection<Snowflake, Queue>();
+        this.queues = new Collection<Snowflake, Queue<OptionsData>>();
 
         this.client.on('voiceStateUpdate',
             (oldState, newState) =>
@@ -52,7 +52,7 @@ export class Player extends EventEmitter {
      * @param {PlayerOptions} [options=this.options]
      * @returns {Queue}
      */
-    createQueue(guildId: Snowflake, options: PlayerOptions & { data?: any } = this.options): Queue {
+    createQueue<D extends OptionsData>(guildId: Snowflake, options: PlayerOptions & { data?: D } = this.options): Queue<D> {
         options = Object.assign(
             {} as PlayerOptions,
             this.options,
@@ -63,15 +63,15 @@ export class Player extends EventEmitter {
         if(!guild)
             throw new DMPError(DMPErrors.INVALID_GUILD);
         if(this.hasQueue(guildId))
-            return this.getQueue(guildId) as Queue;
+            return this.getQueue(guildId) as Queue<D>;
 
         let { data } = options;
         delete options.data;
-        const queue = new Queue(this, guild, options);
+        const queue = new Queue<D>(this, guild, options);
         queue.data = data;
         this.setQueue(guildId, queue);
 
-        return queue as Queue;
+        return queue as Queue<D>;
     }
 
     /**
@@ -98,7 +98,7 @@ export class Player extends EventEmitter {
      * @param {Queue} queue
      * @returns {void}
      */
-    setQueue(guildId: Snowflake, queue: Queue): void {
+    setQueue(guildId: Snowflake, queue: Queue<OptionsData>): void {
         this.queues.set(guildId, queue);
     }
 
@@ -142,6 +142,6 @@ export class Player extends EventEmitter {
     }
 }
 
-export declare interface Player {
-    on<K extends keyof PlayerEvents>(event: K, listener: (...args: PlayerEvents[K]) => void): this;
+export declare interface Player<OptionsData = any> {
+    on<K extends keyof PlayerEvents = any>(event: K, listener: (...args: PlayerEvents<OptionsData>[K]) => void): this;
 }

--- a/src/managers/Queue.ts
+++ b/src/managers/Queue.ts
@@ -6,13 +6,13 @@ import {AudioResource,
 import ytdl from "discord-ytdl-core";
 import { Playlist, Song, Player, Utils, DefaultPlayerOptions, PlayerOptions, PlayOptions, PlaylistOptions, RepeatMode, ProgressBarOptions, ProgressBar, DMPError, DMPErrors, DefaultPlayOptions, DefaultPlaylistOptions } from "..";
 
-export class Queue {
+export class Queue<T = unknown> {
     public player: Player;
     public guild: Guild;
     public connection: StreamConnection;
     public songs: Song[] = [];
     public isPlaying: boolean = false;
-    public data?: any = null;
+    public data?: T;
     public options: PlayerOptions = DefaultPlayerOptions;
     public repeatMode: RepeatMode = RepeatMode.DISABLED;
     public destroyed: boolean = false;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -246,16 +246,17 @@ export enum RepeatMode {
  * @param {Queue} queue Queue
  */
 
-export interface PlayerEvents {
-    channelEmpty: [queue: Queue];
-    songAdd: [queue: Queue, song: Song];
-    playlistAdd: [queue: Queue, playlist: Playlist];
-    queueEnd: [queue: Queue];
-    songChanged: [queue: Queue, newSong: Song, oldSong: Song];
-    songFirst: [queue: Queue, song: Song];
-    clientDisconnect: [queue: Queue];
-    clientUndeafen: [queue: Queue];
-    error: [error: string, queue: Queue];
+export interface PlayerEvents<T = unknown> {
+    channelEmpty: [queue: Queue<T>];
+    songAdd: [queue: Queue<T>, song: Song];
+    playlistAdd: [queue: Queue<T>, playlist: Playlist];
+    queueEnd: [queue: Queue<T>];
+    queueDestroyed: [queue: Queue<T>];
+    songChanged: [queue: Queue<T>, newSong: Song, oldSong: Song];
+    songFirst: [queue: Queue<T>, song: Song];
+    clientDisconnect: [queue: Queue<T>];
+    clientUndeafen: [queue: Queue<T>];
+    error: [error: string, queue: Queue<T>];
 }
 
 /**


### PR DESCRIPTION
Added generic to accept type to be applied in queue data property

### Usage
```typescript
interface MyData {
  foo: string
}

const player = new Player<MyData>(client);

const queue = player.createQueue(guildId, {
  data: {
    foo: "bar"  // <-- type will be inffered
  },
});


// type also applied on the player events queue parameter
player.on('songAdd", (queue) => {
  queue.data // <-- type of MyData
});



```