### PR TITLE
Fix playlist conditional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-music-player",
-  "version": "8.3.2",
+  "version": "8.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-music-player",
-      "version": "8.3.2",
+      "version": "8.3.3",
       "license": "MIT",
       "dependencies": {
         "@discordjs/opus": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-music-player",
-  "version": "8.3.2",
+  "version": "8.3.3",
   "description": "Complete framework to facilitate music commands using discord.js v13",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -320,7 +320,7 @@ export class Utils {
                             SOptions,
                             Queue
                         ).catch(() => null);
-                        if (Result) {
+                        if (Result && Result[0]) {
                             Result[0].data = SOptions.data;
                             return Result[0];
                         } else return null;


### PR DESCRIPTION
Adds an extra check when processing Spotify playlists to avoid a `TypeError` caused by an empty list.