### PR TITLE
Fixed seek method

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Feel free to join [Discord-Music-Player Discord Server](https://discord.gg/6fejZ
 const Discord = require("discord.js");
 const client = new Discord.Client({
     intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_VOICE_STATES]
+    // intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildVoiceStates] for discord.js v14
 });
 const settings = {
     prefix: '!',
@@ -245,3 +246,7 @@ let queue = player.getQueue(message.guild.id);
 let { initMessage } = queue.nowPlaying.data;
 await initMessage.channel.send(`This message object is hold in Song :D`);
 ```
+
+## Example bots made with this package
+
+- [Music bot](https://github.com/elbkr/music-bot) by [elbkr](https://github.com/elbkr)

--- a/src/managers/Queue.ts
+++ b/src/managers/Queue.ts
@@ -229,7 +229,7 @@ export class Queue<T = unknown> {
      * @param {PlayOptions} [options=DefaultPlayOptions]
      * @returns {Promise<Song>}
      */
-    async play(search: Song | string, options: PlayOptions & { immediate?: boolean, seek?: number, data?: any } = DefaultPlayOptions): Promise<Song> {
+    async play(search: Song | string, options: PlayOptions & { immediate?: boolean, data?: any } = DefaultPlayOptions): Promise<Song> {
         if (this.destroyed)
             throw new DMPError(DMPErrors.QUEUE_DESTROYED);
         if (!this.connection)
@@ -248,6 +248,9 @@ export class Queue<T = unknown> {
         if (!options.immediate)
             song.data = data;
 
+        if (options?.seek)
+            song.seekTime = options.seek;
+
         let songLength = this.songs.length;
         if (!options?.immediate && songLength !== 0) {
             if (options?.index! >= 0 && ++options.index! <= songLength)
@@ -261,8 +264,7 @@ export class Queue<T = unknown> {
                 this.songs.splice(options.index!, 0, song);
             else this.songs.push(song);
             this.player.emit('songAdd', this, song);
-        } else if (options.seek)
-            this.songs[0].seekTime = options.seek;
+        }
 
         let quality = this.options.quality;
         song = this.songs[0];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -34,6 +34,7 @@ export interface PlayerOptions {
  * @param {string} [duration] Search sort by Duration
  * @param {string} [sortBy=relevance] Search sort by Sort by
  * @param {boolean} [timecode=false] If url with timecode (?t=) provided, will play from that moment
+ * @param {number} [seek] Seek to a specific time
  * @param {number} [index] If the index was provided, it will add the song after the provided index in the Queue
  * @param {User} [requestedBy] The User who requested the Song
  * @param {string} [localAddress] Custom ipv4/ipv6 address
@@ -42,7 +43,8 @@ export interface PlayOptions {
     uploadDate?: 'hour'|'today'|'week'|'month'|'year',
     duration?: 'short'|'long',
     sortBy?: 'relevance'|'date'|'view count'|'rating',
-    timecode?: boolean,
+    timecode?: boolean;
+    seek?: number;
     index?: number;
     requestedBy?: User,
     localAddress?: string


### PR DESCRIPTION
Now, you can play a song and directly start it in a specific time. 

example usage: 
```js
await queue.play(input, {seek: timeInMS}).catch((_, err) => {
                        if (err) {
                            console.log(err);
                        }});
```
- Added a code comment for discord.js v14 in readme.md
- Added **example bots made with this package** section in the readme _(remove if you don't like it)_
