### PR TITLE
Added Native SoundCloud Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "htmlparser2": "^7.1.2",
     "isomorphic-unfetch": "^3.1.0",
     "libsodium-wrappers": "^0.7.9",
+    "soundcloud-downloader": "^1.0.0",
     "spotify-url-info": "^3.1.7",
     "youtubei": "^0.0.1-rc.34",
     "ytdl-core": "^4.11.2",

--- a/src/managers/Queue.ts
+++ b/src/managers/Queue.ts
@@ -1,6 +1,6 @@
-import { Guild, GuildChannelResolvable, GuildMember, StageChannel, VoiceChannel } from "discord.js";
-import { StreamConnection } from "../voice/StreamConnection";
-import { AudioResource, entersState, joinVoiceChannel, StreamType, VoiceConnectionStatus, DiscordGatewayAdapterCreator } from "@discordjs/voice";
+import {Guild, GuildChannelResolvable, GuildMember, StageChannel, VoiceChannel} from "discord.js";
+import {StreamConnection} from "../voice/StreamConnection";
+import {AudioResource, entersState, joinVoiceChannel, StreamType, VoiceConnectionStatus, DiscordGatewayAdapterCreator} from "@discordjs/voice";
 import ytdl from "discord-ytdl-core";
 import scdl from 'soundcloud-downloader';
 import {
@@ -103,7 +103,7 @@ export class Queue<T = unknown> {
 
         this.guild = guild;
 
-        this.options = { ...DefaultPlayerOptions, ...options };
+        this.options = {...DefaultPlayerOptions, ...options};
     }
 
     /**
@@ -208,16 +208,16 @@ export class Queue<T = unknown> {
                         this.songs.unshift(oldSong!);
                         this.songs[0]._setFirst(false);
                         this.player.emit('songChanged', this, this.songs[0], oldSong);
-                        return this.play(this.songs[0] as Song, { immediate: true });
+                        return this.play(this.songs[0] as Song, {immediate: true});
                     } else if (this.repeatMode === RepeatMode.QUEUE) {
                         this.songs.push(oldSong!);
                         this.songs[this.songs.length - 1]._setFirst(false);
                         this.player.emit('songChanged', this, this.songs[0], oldSong);
-                        return this.play(this.songs[0] as Song, { immediate: true });
+                        return this.play(this.songs[0] as Song, {immediate: true});
                     }
 
                     this.player.emit('songChanged', this, this.songs[0], oldSong);
-                    return this.play(this.songs[0] as Song, { immediate: true });
+                    return this.play(this.songs[0] as Song, {immediate: true});
                 }
             })
             .on('error', (err) => this.player.emit('error', err.message, this));
@@ -240,7 +240,7 @@ export class Queue<T = unknown> {
             DefaultPlayOptions,
             options
         );
-        let { data } = options;
+        let {data} = options;
         delete options.data;
         let song = await Utils.best(search, options, this)
             .catch(error => {
@@ -341,7 +341,7 @@ export class Queue<T = unknown> {
 
         if (songLength === 0) {
             playlist.songs[0]._setFirst();
-            await this.play(playlist.songs[0], { immediate: true });
+            await this.play(playlist.songs[0], {immediate: true});
         }
 
         return playlist;

--- a/src/managers/Queue.ts
+++ b/src/managers/Queue.ts
@@ -2,7 +2,6 @@ import { Guild, GuildChannelResolvable, GuildMember, StageChannel, VoiceChannel 
 import { StreamConnection } from "../voice/StreamConnection";
 import { AudioResource, entersState, joinVoiceChannel, StreamType, VoiceConnectionStatus, DiscordGatewayAdapterCreator } from "@discordjs/voice";
 import ytdl from "discord-ytdl-core";
-import fs from 'fs';
 import scdl from 'soundcloud-downloader';
 import {
     DefaultPlayerOptions,

--- a/src/managers/Song.ts
+++ b/src/managers/Song.ts
@@ -9,6 +9,7 @@ export class Song {
     public url: string;
     public thumbnail: string;
     public requestedBy?: User;
+    public domain: string;
     public duration: string;
     public isLive: boolean;
     public isFirst: boolean;
@@ -67,6 +68,12 @@ export class Song {
          */
 
         /**
+         * Song domain
+         * @name Song#domain
+         * @type {string}
+         */
+
+        /**
          * Song duration
          * @name Song#duration
          * @type {string}
@@ -111,6 +118,8 @@ export class Song {
         this.thumbnail = raw.thumbnail;
 
         this.requestedBy = requestedBy;
+
+        this.domain = raw.domain;
 
         this.duration = raw.duration;
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,5 @@
-import { AudioPlayerError, AudioResource } from "@discordjs/voice";
-import { User } from "discord.js";
+import {AudioPlayerError, AudioResource} from "@discordjs/voice";
+import {User} from "discord.js";
 import { Song, Queue, Playlist } from "..";
 
 /**
@@ -22,7 +22,7 @@ export interface PlayerOptions {
     deafenOnJoin?: boolean,
     timeout?: number,
     volume?: number,
-    quality?: 'low' | 'high',
+    quality?: 'low'|'high',
     localAddress?: string,
     ytdlRequestOptions?: object,
 }
@@ -40,9 +40,9 @@ export interface PlayerOptions {
  * @param {string} [localAddress] Custom ipv4/ipv6 address
  */
 export interface PlayOptions {
-    uploadDate?: 'hour' | 'today' | 'week' | 'month' | 'year',
-    duration?: 'short' | 'long',
-    sortBy?: 'relevance' | 'date' | 'view count' | 'rating',
+    uploadDate?: 'hour'|'today'|'week'|'month'|'year',
+    duration?: 'short'|'long',
+    sortBy?: 'relevance'|'date'|'view count'|'rating',
     timecode?: boolean;
     seek?: number;
     index?: number;
@@ -175,7 +175,7 @@ export interface RawPlaylist {
     author: string,
     url: string,
     songs: Song[],
-    type: 'playlist' | 'album'
+    type: 'playlist'|'album'
 }
 
 /**
@@ -189,7 +189,7 @@ export interface RawPlaylist {
 export enum RepeatMode {
     DISABLED,
     SONG,
-    QUEUE,
+    QUEUE ,
 }
 
 /**
@@ -307,7 +307,7 @@ export interface StreamConnectionEvents {
 
 export interface RawApplePlaylist {
     name: string
-    type: 'playlist' | 'album'
+    type: 'playlist'|'album'
     author: string
     tracks: { artist: string, title: string }[]
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,5 @@
-import {AudioPlayerError, AudioResource } from "@discordjs/voice";
-import {User} from "discord.js";
+import { AudioPlayerError, AudioResource } from "@discordjs/voice";
+import { User } from "discord.js";
 import { Song, Queue, Playlist } from "..";
 
 /**
@@ -22,7 +22,7 @@ export interface PlayerOptions {
     deafenOnJoin?: boolean,
     timeout?: number,
     volume?: number,
-    quality?: 'low'|'high',
+    quality?: 'low' | 'high',
     localAddress?: string,
     ytdlRequestOptions?: object,
 }
@@ -40,9 +40,9 @@ export interface PlayerOptions {
  * @param {string} [localAddress] Custom ipv4/ipv6 address
  */
 export interface PlayOptions {
-    uploadDate?: 'hour'|'today'|'week'|'month'|'year',
-    duration?: 'short'|'long',
-    sortBy?: 'relevance'|'date'|'view count'|'rating',
+    uploadDate?: 'hour' | 'today' | 'week' | 'month' | 'year',
+    duration?: 'short' | 'long',
+    sortBy?: 'relevance' | 'date' | 'view count' | 'rating',
     timecode?: boolean;
     seek?: number;
     index?: number;
@@ -146,6 +146,7 @@ export const DefaultProgressBarOptions: ProgressBarOptions = {
  * @property {string} author
  * @property {string} url
  * @property {string} thumbnail
+ * @property {string} domain
  * @property {string} duration
  * @property {boolean} isLive
  */
@@ -154,6 +155,7 @@ export interface RawSong {
     author: string,
     url: string,
     thumbnail: string,
+    domain: string,
     duration: string,
     isLive: boolean
     seekTime?: number;
@@ -173,7 +175,7 @@ export interface RawPlaylist {
     author: string,
     url: string,
     songs: Song[],
-    type: 'playlist'|'album'
+    type: 'playlist' | 'album'
 }
 
 /**
@@ -187,7 +189,7 @@ export interface RawPlaylist {
 export enum RepeatMode {
     DISABLED,
     SONG,
-    QUEUE ,
+    QUEUE,
 }
 
 /**
@@ -305,7 +307,7 @@ export interface StreamConnectionEvents {
 
 export interface RawApplePlaylist {
     name: string
-    type: 'playlist'|'album'
+    type: 'playlist' | 'album'
     author: string
     tracks: { artist: string, title: string }[]
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -11,17 +11,17 @@ import {
     Song,
 } from "..";
 import fetch from 'isomorphic-unfetch';
-import YTSR, { Video } from 'ytsr';
+import YTSR, {Video} from 'ytsr';
 import scdl from 'soundcloud-downloader';
 import Spotify from "spotify-url-info";
-import { getPlaylist, getSong } from "apple-music-metadata";
-import { Client, Playlist as IPlaylist, Video as IVideo, VideoCompact } from "youtubei";
-import { ChannelType, GuildChannel } from "discord.js";
+import {getPlaylist, getSong} from "apple-music-metadata";
+import {Client, Playlist as IPlaylist, Video as IVideo, VideoCompact} from "youtubei";
+import {ChannelType, GuildChannel} from "discord.js";
 
 
 
 let YouTube = new Client();
-const { getData, getPreview } = Spotify(fetch);
+const {getData, getPreview} = Spotify(fetch);
 
 export class Utils {
     static regexList = {
@@ -96,7 +96,7 @@ export class Utils {
                     (
                         await YTSR.getFilters(Filters.url!)
                     )
-                        .get('Upload date')!, ([name, value]) => ({ name, url: value.url })
+                        .get('Upload date')!, ([name, value]) => ({name, url: value.url})
                 )
                     .find(o => o.name.toLowerCase().includes(SOptions?.uploadDate!))
                     ?? Filters;
@@ -107,7 +107,7 @@ export class Utils {
                     (
                         await YTSR.getFilters(Filters.url!)
                     )
-                        .get('Duration')!, ([name, value]) => ({ name, url: value.url })
+                        .get('Duration')!, ([name, value]) => ({name, url: value.url})
                 )
                     .find(o => o.name.toLowerCase().startsWith(SOptions?.duration!))
                     ?? Filters;
@@ -118,7 +118,7 @@ export class Utils {
                     (
                         await YTSR.getFilters(Filters.url!)
                     )
-                        .get('Sort by')!, ([name, value]) => ({ name, url: value.url })
+                        .get('Sort by')!, ([name, value]) => ({name, url: value.url})
                 )
                     .find(o => o.name.toLowerCase().includes(SOptions?.sortBy!))
                     ?? Filters;
@@ -287,7 +287,7 @@ export class Utils {
 
         if (SoundCloudPlaylistLink) {
 
-            let SoundCloudResultData = await scdl.getSetInfo(Search).catch(() => { throw DMPErrors.INVALID_PLAYLIST; })
+            let SoundCloudResultData = await scdl.getSetInfo(Search).catch(() => {throw DMPErrors.INVALID_PLAYLIST;})
 
             let SoundCloudResult: RawPlaylist = {
                 name: SoundCloudResultData.permalink,


### PR DESCRIPTION
Good Afternoon,

I use this package a lot for my bot, and I decided that I wanted to help out. One problem with this package is the lack of SoundCloud support. So, I decided to make some changes that would allow SoundCloud songs / playlists to be played.

**Changes:**

- Added direct native SoundCloud support for both individual songs and playlists.  

- I believe there is a version conflict between one of the packages in package.json, which would cause an error building on line 161 of Queue.ts. I fixed it by doing: ```adapterCreator: channel.guild.voiceAdapterCreator as unknown as DiscordGatewayAdapterCreator,```. Seems to be a common problem.


Please let me know what you think. If there's anything you want changed, I'd be happy to oblige. 