### PR TITLE
Potential Fix Livestreams not working

### DIFF
--- a/src/managers/Queue.ts
+++ b/src/managers/Queue.ts
@@ -279,7 +279,7 @@ export class Queue<T = unknown> {
             encoderArgs: [],
             quality: quality!.toLowerCase() === 'low' ? 'lowestaudio' : 'highestaudio',
             highWaterMark: 1 << 25,
-            filter: 'audioonly'
+            filter: !song.duration ? null : 'audioonly'
         })
             .on('error', (error: { message: string; }) => {
                 if (!/Status code|premature close/i.test(error.message))


### PR DESCRIPTION
Hello,

I've found a fix for the live streams not working that's within the scope of this module.
`ytdl-core` apparently doesn't like livestreams and filters mixed together so I added a check that removes the filter when the song duration is null - <Song>.isLive doesn't seem to work anymore (it's always false). If the song is not a livestream, it'll fall back to the default behaviour. Some said that one also has to add `isHLS: true` when the song's a livestream, however this works for me as is, ytdl probably auto-sets that property. 

Please let me know if this is something you can allow. 

Relevant issues:
https://github.com/fent/node-ytdl-core/issues/839
https://github.com/fent/node-ytdl-core/issues/817