### PR TITLE
fix: clear keepAliveInterval

### DIFF
--- a/src/managers/Queue.ts
+++ b/src/managers/Queue.ts
@@ -160,6 +160,18 @@ export class Queue<T = unknown> {
             adapterCreator: channel.guild.voiceAdapterCreator,
             selfDeaf: this.options.deafenOnJoin
         });
+        connection.on('stateChange', (oldState, newState) => {
+            const oldNetworking = Reflect.get(oldState, 'networking');
+            const newNetworking = Reflect.get(newState, 'networking');
+          
+            const networkStateChangeHandler = (_oldNetworkState, newNetworkState) => {
+                const newUdp = Reflect.get(newNetworkState, 'udp');
+                clearInterval(newUdp?.keepAliveInterval);
+            }
+          
+            oldNetworking?.off('stateChange', networkStateChangeHandler);
+            newNetworking?.on('stateChange', networkStateChangeHandler);
+        });
         let _connection: StreamConnection;
         try {
             connection = await entersState(connection, VoiceConnectionStatus.Ready, 15 * 1000);


### PR DESCRIPTION
According to [this thread](https://github.com/discordjs/discord.js/issues/9185), they recently changed the discord API introducing this keepAlive counter and the connection was being shut down after 60 seconds (with an AbortError).

This is a workaround to prevent disconnecting and doesn't require a core (Discord) API change.

Keep in mind that this is provisory and we'll need to handle these changes later.
Here's the official announcement: 
![image](https://user-images.githubusercontent.com/13181199/222777048-06e0167c-5321-4b9c-b643-03a6dac0f482.png)
