### PR TITLE
Update @discordjs/voice to fix keepAlive timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-music-player",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "Complete framework to facilitate music commands using discord.js v14 and v13.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -33,7 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "@discordjs/opus": "^0.8.0",
-    "@discordjs/voice": "^0.11.0",
+    "@discordjs/voice": "^0.15.0",
     "apple-music-metadata": "^1.0.10",
     "axios": "^0.22.0",
     "axios-retry": "^3.2.0",


### PR DESCRIPTION
See PR https://github.com/SushiBtw/discord-music-player/pull/322 and Issue https://github.com/SushiBtw/discord-music-player/issues/323

We no longer need to implement a manual quick fix. Discord.js [released a new version](https://github.com/discordjs/discord.js/releases/tag/%40discordjs%2Fvoice%400.15.0) that addresses the keepAlive 60 second timeout issue. This PR updates @discordjs/voice to that version.

@SushiBtw - this is really important, because without an update, all connections will continue to time out after 60 seconds.